### PR TITLE
Fix a typo in khr cooperative matrix shader

### DIFF
--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -450,7 +450,7 @@ void main()
     barrier();
 
     coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> a;
-    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator> b;
+    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseB> b;
     coopMatLoad(a, tmp_a, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
     coopMatLoad(b, tmp_b, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
 
@@ -458,22 +458,22 @@ void main()
 
     for (int i = 0; i < loop; i++)
     {
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
-        c = coopMatMulAdd(a, c, b);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
     }
 
     coopMatStore(c, tmp_a, 0, 2, gl_CooperativeMatrixLayoutRowMajor);


### PR DESCRIPTION
I discovered the matrix shader have some issues under KHR. According to the glsl
specification, operands of matrix multiplication must be same of the
corresponding type.

> The dimensions of A, B, and C, must form a valid matrix multiply (e.g.
> the number of columns of A must match the number of rows of B). A, B,
> and C must have the same scope. A's type must use gl_MatrixUseA.
> B's type must use gl_MatrixUseB. C's type must use gl_MatrixUseAccumulator.
> The type of the result matches the type of C.

This is not required for extensions under Nv. But
`glsl_fp16_matrix_khr_8_8_16_data` is correct, I believe it's a typo.