### PR TITLE
feature update

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,6 @@ jobs:
         sudo InstallVulkan-${{ env.VULKANSDK_VERSION }}.app/Contents/MacOS/InstallVulkan-${{ env.VULKANSDK_VERSION }} --root $GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
     - name: build-x86_64
       run: |
-        export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-x86_64 && cd build-x86_64
         cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" \
             -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
@@ -58,7 +57,6 @@ jobs:
         cmake --build . -j 4
     - name: build-arm64
       run: |
-        export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-arm64 && cd build-arm64
         cmake -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,25 +1,26 @@
 name: CI
 on: [push, pull_request]
+
 env:
-  VULKANSDK_VERSION: 1.3.231.1
+  VULKANSDK_VERSION: 1.4.309.0
   DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  UseMultiToolTask: true
+
+concurrency:
+  group: CI-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
   windows:
     runs-on: windows-latest
-    env:
-      UseMultiToolTask: true
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: vulkansdk
-      run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/windows/VulkanSDK-${{ env.VULKANSDK_VERSION }}-Installer.exe?Human=true -OutFile VulkanSDK-${{ env.VULKANSDK_VERSION }}-Installer.exe
-        ./VulkanSDK-${{ env.VULKANSDK_VERSION }}-Installer.exe --root $env:GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
     - name: build
       run: |
-        $env:VULKAN_SDK="$env:GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}"
         mkdir build; cd build
         cmake -A x64 ..
         cmake --build . --config Release -j 4
@@ -30,13 +31,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: vulkansdk
-      run: |
-        wget -q https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.VULKANSDK_VERSION }}.tar.gz?Human=true -O vulkansdk-linux-x86_64-${{ env.VULKANSDK_VERSION }}.tar.gz
-        tar -xf vulkansdk-linux-x86_64-${{ env.VULKANSDK_VERSION }}.tar.gz
     - name: build
       run: |
-        export VULKAN_SDK=`pwd`/${{ env.VULKANSDK_VERSION }}/x86_64
         mkdir build && cd build
         cmake ..
         cmake --build . -j 4
@@ -49,17 +45,15 @@ jobs:
         submodules: 'recursive'
     - name: vulkansdk
       run: |
-        wget -q https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.dmg?Human=true -O vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.dmg
-        hdiutil attach vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.dmg
-        cp -r /Volumes/vulkansdk-macos-${{ env.VULKANSDK_VERSION }} .
-        hdiutil detach /Volumes/vulkansdk-macos-${{ env.VULKANSDK_VERSION }}
-        sudo vulkansdk-macos-${{ env.VULKANSDK_VERSION }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
+        wget -q https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.zip?Human=true -O vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.zip
+        unzip -q vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.zip
+        sudo InstallVulkan-${{ env.VULKANSDK_VERSION }}.app/Contents/MacOS/InstallVulkan-${{ env.VULKANSDK_VERSION }} --root $GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
     - name: build-x86_64
       run: |
         export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-x86_64 && cd build-x86_64
         cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" \
-            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
+            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
             ..
         cmake --build . -j 4
     - name: build-arm64
@@ -67,6 +61,6 @@ jobs:
         export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-arm64 && cd build-arm64
         cmake -DCMAKE_OSX_ARCHITECTURES="arm64" \
-            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
+            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
             ..
         cmake --build . -j 4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,6 @@ jobs:
         sudo InstallVulkan-${{ env.VULKANSDK_VERSION }}.app/Contents/MacOS/InstallVulkan-${{ env.VULKANSDK_VERSION }} --root $GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
     - name: build-x86_64
       run: |
-        export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-x86_64 && cd build-x86_64
         cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" \
             -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
@@ -75,7 +74,6 @@ jobs:
         cmake --build . -j 4
     - name: build-arm64
       run: |
-        export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-arm64 && cd build-arm64
         cmake -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
 name: release
-on:
-  push:
-    tags:
-      - '*'
+on: workflow_dispatch
 
 env:
-  VULKANSDK_VERSION: 1.3.231.1
+  VULKANSDK_VERSION: 1.4.309.0
   DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+  UseMultiToolTask: true
   APPLICATION_NAME: vkpeak
 
 jobs:
@@ -22,24 +20,21 @@ jobs:
       run: echo "APPNAME=${APPLICATION_NAME}" >> $GITHUB_OUTPUT
     - name: get-version
       id: get_version
-      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+      run: |
+        DATE=`date +'%Y%m%d'`
+        echo "VERSION=${DATE}" >> $GITHUB_OUTPUT
 
   ubuntu:
     needs: [setup]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       PACKAGENAME: ${{ needs.setup.outputs.APPNAME }}-${{ needs.setup.outputs.VERSION }}-ubuntu
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: vulkansdk
-      run: |
-        wget -q https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.VULKANSDK_VERSION }}.tar.gz?Human=true -O vulkansdk-linux-x86_64-${{ env.VULKANSDK_VERSION }}.tar.gz
-        tar -xf vulkansdk-linux-x86_64-${{ env.VULKANSDK_VERSION }}.tar.gz
     - name: build
       run: |
-        export VULKAN_SDK=`pwd`/${{ env.VULKANSDK_VERSION }}/x86_64
         mkdir build && cd build
         cmake ..
         cmake --build . -j 4
@@ -67,17 +62,15 @@ jobs:
         submodules: 'recursive'
     - name: vulkansdk
       run: |
-        wget -q https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.dmg?Human=true -O vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.dmg
-        hdiutil attach vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.dmg
-        cp -r /Volumes/vulkansdk-macos-${{ env.VULKANSDK_VERSION }} .
-        hdiutil detach /Volumes/vulkansdk-macos-${{ env.VULKANSDK_VERSION }}
-        sudo vulkansdk-macos-${{ env.VULKANSDK_VERSION }}/InstallVulkan.app/Contents/MacOS/InstallVulkan --root $GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
+        wget -q https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/mac/vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.zip?Human=true -O vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.zip
+        unzip -q vulkansdk-macos-${{ env.VULKANSDK_VERSION }}.zip
+        sudo InstallVulkan-${{ env.VULKANSDK_VERSION }}.app/Contents/MacOS/InstallVulkan-${{ env.VULKANSDK_VERSION }} --root $GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
     - name: build-x86_64
       run: |
         export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-x86_64 && cd build-x86_64
         cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" \
-            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
+            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
             ..
         cmake --build . -j 4
     - name: build-arm64
@@ -85,7 +78,7 @@ jobs:
         export VULKAN_SDK=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS
         mkdir build-arm64 && cd build-arm64
         cmake -DCMAKE_OSX_ARCHITECTURES="arm64" \
-            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
+            -DVulkan_LIBRARY=$GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}/macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a \
             ..
         cmake --build . -j 4
     - name: package
@@ -111,13 +104,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - name: vulkansdk
-      run: |
-        Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/${{ env.VULKANSDK_VERSION }}/windows/VulkanSDK-${{ env.VULKANSDK_VERSION }}-Installer.exe?Human=true -OutFile VulkanSDK-${{ env.VULKANSDK_VERSION }}-Installer.exe
-        ./VulkanSDK-${{ env.VULKANSDK_VERSION }}-Installer.exe --root $env:GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }} --accept-licenses --default-answer --confirm-command install
     - name: build
       run: |
-        $env:VULKAN_SDK="$env:GITHUB_WORKSPACE/${{ env.VULKANSDK_VERSION }}"
         mkdir build; cd build
         cmake -A x64 ..
         cmake --build . --config Release -j 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ option(WITH_LAYER_erf "" OFF)
 option(WITH_LAYER_diag "" OFF)
 option(WITH_LAYER_celu "" OFF)
 option(WITH_LAYER_shrink "" OFF)
+option(WITH_LAYER_rmsnorm "" OFF)
+option(WITH_LAYER_spectrogram "" OFF)
+option(WITH_LAYER_inversespectrogram "" OFF)
 
 add_subdirectory(ncnn)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 project(vkpeak)
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_BUILD_TYPE release)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE release CACHE STRING "Choose the type of build" FORCE)
+endif()
 
 # build ncnn library
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ncnn/CMakeLists.txt")

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A synthetic benchmarking tool to measure peak capabilities of vulkan devices. It
 
 ## [Download](https://github.com/nihui/vkpeak/releases)
 
-Download Windows/Linux/MacOS Executable for Intel/AMD/Nvidia GPU
+Download Windows/Linux/MacOS Executable for Intel/AMD/Nvidia/Apple GPU
 
 **https://github.com/nihui/vkpeak/releases**
 
@@ -26,19 +26,7 @@ If you encounter a crash or error, try upgrading your GPU driver:
 
 ## Build from Source
 
-1. Download and setup the Vulkan SDK from https://vulkan.lunarg.com/
-  - For Linux distributions, you can either get the essential build requirements from package manager
-```shell
-dnf install vulkan-headers vulkan-loader-devel
-```
-```shell
-apt-get install libvulkan-dev
-```
-```shell
-pacman -S vulkan-headers vulkan-icd-loader
-```
-
-2. Clone this project with all submodules
+1. Clone this project with all submodules
 
 ```shell
 git clone https://github.com/nihui/vkpeak.git
@@ -46,8 +34,8 @@ cd vkpeak
 git submodule update --init --recursive
 ```
 
-3. Build with CMake
-  - You can pass -DUSE_STATIC_MOLTENVK=ON option to avoid linking the vulkan loader library on MacOS
+2. Build with CMake
+  - You can pass -DVulkan_LIBRARY=<path to your macOS/lib/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a> option to link static MoltenVK library on MacOS, MoltenVK is part of Vulkan SDK from https://vulkan.lunarg.com/
 
 ```shell
 mkdir build

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -908,7 +908,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -940,7 +940,7 @@ void main()
         c = coopMatMulAddNV(a, b, c);
     }
 
-    coopMatStoreNV(c, c_blob_data, gx, 0, false);
+    coopMatStoreNV(c, c_blob_data, gx * (M * N) / 2, N / 2, false);
 }
 )";
 
@@ -957,7 +957,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -991,7 +991,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStoreNV(c0, c_blob_data, gx, 0, false);
+    coopMatStoreNV(c, c_blob_data, gx * (M * N) / 2, N / 2, false);
 }
 )";
 
@@ -1008,7 +1008,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1040,7 +1040,7 @@ void main()
         c = coopMatMulAdd(a, b, c);
     }
 
-    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c, c_blob_data, gx * (M * N) / 2, N / 2, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1057,7 +1057,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1091,7 +1091,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c0, c_blob_data, gx * (M * N) / 2, N / 2, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1108,7 +1108,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1140,7 +1140,7 @@ void main()
         c = coopMatMulAddNV(a, b, c);
     }
 
-    coopMatStoreNV(c, c_blob_data, gx, 0, false);
+    coopMatStoreNV(c, c_blob_data, gx * (M * N), N, false);
 }
 )";
 
@@ -1157,7 +1157,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1191,7 +1191,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStoreNV(c0, c_blob_data, gx, 0, false);
+    coopMatStoreNV(c0, c_blob_data, gx * (M * N), N, false);
 }
 )";
 
@@ -1208,7 +1208,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1240,7 +1240,7 @@ void main()
         c = coopMatMulAdd(a, b, c);
     }
 
-    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c, c_blob_data, gx * (M * N), N, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1257,7 +1257,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1291,7 +1291,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c0, c_blob_data, gx * (M * N), N, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1341,7 +1341,7 @@ void main()
         c = coopMatMulAddNV(a, b, c);
     }
 
-    coopMatStoreNV(c, c_blob_data, gx * (M * N), 0, false);
+    coopMatStoreNV(c, c_blob_data, gx * (M * N), N, false);
 }
 )";
 
@@ -1393,7 +1393,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStoreNV(c0, c_blob_data, gx * (M * N), 0, false);
+    coopMatStoreNV(c0, c_blob_data, gx * (M * N), N, false);
 }
 )";
 
@@ -1442,7 +1442,7 @@ void main()
         c = coopMatMulAdd(a, b, c);
     }
 
-    coopMatStore(c, c_blob_data, gx * (M * N), 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c, c_blob_data, gx * (M * N), N, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1493,7 +1493,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStore(c0, c_blob_data, gx * (M * N), 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c0, c_blob_data, gx * (M * N), N, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1511,7 +1511,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1543,7 +1543,7 @@ void main()
         c = coopMatMulAdd(a, b, c);
     }
 
-    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c, c_blob_data, gx * (M * N) / 2, N / 2, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1561,7 +1561,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1598,7 +1598,7 @@ void main()
     coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c3 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(c1);
 
     c0 = coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(c2 + c3);
-    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c0, c_blob_data, gx * (M * N) / 2, N / 2, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1616,7 +1616,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1648,7 +1648,7 @@ void main()
         c = coopMatMulAdd(a, b, c);
     }
 
-    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c, c_blob_data, gx * (M * N), N, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -1666,7 +1666,7 @@ layout (constant_id = 1) const int M = 1;
 layout (constant_id = 2) const int N = 1;
 layout (constant_id = 3) const int K = 1;
 
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
@@ -1700,7 +1700,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(c0, c_blob_data, gx * (M * N), N, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -8,96 +8,86 @@
 static const char glsl_p1_data[] = R"(
 #version 450
 
-#if NCNN_fp16_storage
-#extension GL_EXT_shader_16bit_storage: require
-#endif
-#if NCNN_fp16_arithmetic
-#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
-#endif
-
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { sfp c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    afp a = afp(gx);
-    afp b = afp(lx);
+    afp c0 = afp(gx);
+    afp c1 = afp(lx);
 
-    afp c = afp(1.f);
+    afp a = c0;
+    afp b = c1;
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    buffer_st1(c_blob_data, gx, c);
+    c0 = c0 + c1;
+    c_blob_data[gx] = sfp(c0);
 }
 )";
 
 static const char glsl_p4_data[] = R"(
 #version 450
 
-#if NCNN_fp16_storage
-#extension GL_EXT_shader_16bit_storage: require
-#endif
-#if NCNN_fp16_arithmetic
-#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
-#endif
-
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { sfpvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    afpvec4 a = afpvec4(gx) + afpvec4(0,1,2,-3);
-    afpvec4 b = afpvec4(lx) + afpvec4(2,3,5,-7);
+    afpvec4 c0 = afpvec4(gx);
+    afpvec4 c1 = afpvec4(lx);
 
-    afpvec4 c = afpvec4(1.f);
+    afpvec4 a = c0 + afpvec4(0,1,2,-3);
+    afpvec4 b = c1 + afpvec4(2,3,5,-7);
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    buffer_st4(c_blob_data, gx, c);
+    c0 = c0 + c1;
+    c_blob_data[gx] = sfp((c0[0] + c0[1]) + (c0[2] + c0[3]));
 }
 )";
 
@@ -110,35 +100,37 @@ layout (binding = 0) writeonly buffer c_blob { double c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    double a = double(gx);
-    double b = double(lx);
+    double c0 = double(gx);
+    double c1 = double(lx);
 
-    double c = double(1.f);
+    double a = c0;
+    double b = c1;
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    c_blob_data[gx] = c;
+    c0 = c0 + c1;
+    c_blob_data[gx] = c0;
 }
 )";
 
@@ -147,39 +139,41 @@ static const char glsl_fp64_p4_data[] = R"(
 
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { dvec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { double c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    dvec4 a = dvec4(gx) + dvec4(0,1,2,-3);
-    dvec4 b = dvec4(lx) + dvec4(2,3,5,-7);
+    dvec4 c0 = dvec4(gx);
+    dvec4 c1 = dvec4(lx);
 
-    dvec4 c = dvec4(1.f);
+    dvec4 a = c0 + dvec4(0,1,2,-3);
+    dvec4 b = c1 + dvec4(2,3,5,-7);
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    c_blob_data[gx] = c;
+    c0 = c0 + c1;
+    c_blob_data[gx] = (c0[0] + c0[1]) + (c0[2] + c0[3]);
 }
 )";
 
@@ -192,35 +186,37 @@ layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    int a = int(gx);
-    int b = int(lx);
+    int c0 = int(gx);
+    int c1 = int(lx);
 
-    int c = int(1);
+    int a = c0;
+    int b = c1;
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    c_blob_data[gx] = c;
+    c0 = c0 + c1;
+    c_blob_data[gx] = c0;
 }
 )";
 
@@ -229,39 +225,41 @@ static const char glsl_int32_p4_data[] = R"(
 
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { ivec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    ivec4 a = ivec4(gx) + ivec4(0,1,2,-3);
-    ivec4 b = ivec4(lx) + ivec4(2,3,5,-7);
+    ivec4 c0 = ivec4(gx);
+    ivec4 c1 = ivec4(lx);
 
-    ivec4 c = ivec4(1);
+    ivec4 a = c0 + ivec4(0,1,2,-3);
+    ivec4 b = c1 + ivec4(2,3,5,-7);
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    c_blob_data[gx] = c;
+    c0 = c0 + c1;
+    c_blob_data[gx] = (c0[0] + c0[1]) + (c0[2] + c0[3]);
 }
 )";
 
@@ -277,35 +275,37 @@ layout (binding = 0) writeonly buffer c_blob { int16_t c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    int16_t a = int16_t(gx);
-    int16_t b = int16_t(lx);
+    int16_t c0 = int16_t(gx);
+    int16_t c1 = int16_t(lx);
 
-    int16_t c = int16_t(1);
+    int16_t a = c0;
+    int16_t b = c1;
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    c_blob_data[gx] = c;
+    c0 = c0 + c1;
+    c_blob_data[gx] = c0;
 }
 )";
 
@@ -317,39 +317,41 @@ static const char glsl_int16_p4_data[] = R"(
 
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { i16vec4 c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { int16_t c_blob_data[]; };
 
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    i16vec4 a = i16vec4(gx) + i16vec4(0,1,2,-3);
-    i16vec4 b = i16vec4(lx) + i16vec4(2,3,5,-7);
+    i16vec4 c0 = i16vec4(gx);
+    i16vec4 c1 = i16vec4(lx);
 
-    i16vec4 c = i16vec4(1);
+    i16vec4 a = c0 + i16vec4(0,1,2,-3);
+    i16vec4 b = c1 + i16vec4(2,3,5,-7);
 
     for (int i = 0; i < loop; i++)
     {
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
-        c = a * c + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
+        c0 = a * c0 + b;
+        c1 = a * c1 + b;
     }
 
-    c_blob_data[gx] = c;
+    c0 = c0 + c1;
+    c_blob_data[gx] = (c0[0] + c0[1]) + (c0[2] + c0[3]);
 }
 )";
 
@@ -363,60 +365,45 @@ static const char glsl_fp16_matrix_nv_data[] = R"(
 #extension GL_NV_cooperative_matrix: require
 
 layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
 
 layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
 
-shared uvec4 tmp_a[16*2];
-shared uvec4 tmp_b[16*2];
-
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    if (lx < 32)
-    {
-        tmp_a[lx] = uvec4(gx);
-        tmp_b[lx] = uvec4(lx);
-    }
+    fcoopmatNV<16, gl_ScopeSubgroup, M, K> a = fcoopmatNV<16, gl_ScopeSubgroup, M, K>(float(gx));
+    fcoopmatNV<16, gl_ScopeSubgroup, K, N> b = fcoopmatNV<16, gl_ScopeSubgroup, K, N>(float(lx));
 
-    barrier();
-
-    fcoopmatNV<16, gl_ScopeSubgroup, 16, 16> a;
-    fcoopmatNV<16, gl_ScopeSubgroup, 16, 16> b;
-    coopMatLoadNV(a, tmp_a, 0, 2, false);
-    coopMatLoadNV(b, tmp_b, 0, 2, false);
-
-    fcoopmatNV<16, gl_ScopeSubgroup, 16, 16> c = fcoopmatNV<16, gl_ScopeSubgroup, 16, 16>(0.f);
+    fcoopmatNV<16, gl_ScopeSubgroup, M, N> c0 = fcoopmatNV<16, gl_ScopeSubgroup, M, N>(float(gx));
+    fcoopmatNV<16, gl_ScopeSubgroup, M, N> c1 = fcoopmatNV<16, gl_ScopeSubgroup, M, N>(float(lx));
 
     for (int i = 0; i < loop; i++)
     {
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
     }
 
-    coopMatStoreNV(c, tmp_a, 0, 2, false);
-
-    barrier();
-
-    if (lx < 32)
-    {
-        c_blob_data[gx] = tmp_a[lx];
-    }
+    c0 = c0 + c1;
+    coopMatStoreNV(c0, c_blob_data, gx, 0, false);
 }
 )";
 
@@ -430,128 +417,45 @@ static const char glsl_fp16_matrix_khr_data[] = R"(
 #extension GL_KHR_cooperative_matrix: require
 
 layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
 
 layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
 
-shared uvec4 tmp_a[16*2];
-shared uvec4 tmp_b[16*2];
-
 void main()
 {
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
 
-    if (lx < 32)
-    {
-        tmp_a[lx] = uvec4(gx);
-        tmp_b[lx] = uvec4(lx);
-    }
+    coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
 
-    barrier();
-
-    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> a;
-    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseB> b;
-    coopMatLoad(a, tmp_a, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
-    coopMatLoad(b, tmp_b, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
-
-    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator> c = coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator>(0.f);
+    coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c0 = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+    coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c1 = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(lx));
 
     for (int i = 0; i < loop; i++)
     {
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
     }
 
-    coopMatStore(c, tmp_a, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
-
-    barrier();
-
-    if (lx < 32)
-    {
-        c_blob_data[gx] = tmp_a[lx];
-    }
-}
-)";
-
-static const char glsl_fp16_matrix_khr_8_8_16_data[] = R"(
-#version 450
-
-#extension GL_EXT_shader_16bit_storage: require
-#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
-#extension GL_KHR_memory_scope_semantics: require
-#extension GL_EXT_shader_explicit_arithmetic_types: require
-#extension GL_KHR_cooperative_matrix: require
-
-layout (constant_id = 0) const int loop = 1;
-
-layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
-
-shared uvec4 tmp_a[16];
-shared uvec4 tmp_b[16];
-shared uvec4 tmp_c[8];
-
-void main()
-{
-    const int gx = int(gl_GlobalInvocationID.x);
-    const int lx = int(gl_LocalInvocationID.x);
-
-    if (lx < 16)
-    {
-        tmp_a[lx] = uvec4(gx);
-        tmp_b[lx] = uvec4(lx);
-    }
-
-    barrier();
-
-    coopmat<float16_t, gl_ScopeSubgroup, 8, 16, gl_MatrixUseA> a;
-    coopmat<float16_t, gl_ScopeSubgroup, 16, 8, gl_MatrixUseB> b;
-    coopMatLoad(a, tmp_a, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
-    coopMatLoad(b, tmp_b, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
-
-    coopmat<float16_t, gl_ScopeSubgroup, 8, 8, gl_MatrixUseAccumulator> c = coopmat<float16_t, gl_ScopeSubgroup, 8, 8, gl_MatrixUseAccumulator>(0.f);
-
-    for (int i = 0; i < loop; i++)
-    {
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-        c = coopMatMulAdd(a, b, c);
-    }
-
-    coopMatStore(c, tmp_c, 0, 2, gl_CooperativeMatrixLayoutRowMajor);
-
-    barrier();
-
-    if (lx < 8)
-    {
-        c_blob_data[gx] = tmp_c[lx];
-    }
+    c0 = c0 + c1;
+    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
 }
 )";
 
@@ -585,17 +489,8 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
         return 0;
     }
 
-    // query shader fp64 feature
-    bool has_shader_fp64 = false;
-    {
-        VkPhysicalDevice physicalDevice = vkdev->info.physical_device();
-
-        VkPhysicalDeviceFeatures features;
-        ncnn::vkGetPhysicalDeviceFeatures(physicalDevice, &features);
-
-        has_shader_fp64 = features.shaderFloat64;
-    }
-
+    // check shader fp64 feature
+    bool has_shader_fp64 = vkdev->info.physicalDevicefeatures().shaderFloat64;
     if (!has_shader_fp64 && (storage_type == 2 || arithmetic_type == 2))
     {
         return 0;
@@ -609,7 +504,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
 
     ncnn::VkAllocator* allocator = vkdev->acquire_blob_allocator();
 
-    // reuse a b c storage, max 1G for each
+    // reuse c storage, max 1G
     int buffer_size = std::min((int)(vkdev->get_heap_budget() / 8), 1 * 1024) * 1024 * 1024;
     if (vkdev->info.type() == 1)
     {
@@ -629,10 +524,15 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
         // fp16 / int16
         elemsize = 2;
     }
-    else // if (storage_type == 2)
+    else if (storage_type == 2)
     {
         // fp64
         elemsize = 8;
+    }
+    else if (storage_type == 5)
+    {
+        // int8
+        elemsize = 1;
     }
 
     int local_size_x = std::min(128, std::max(1, (int)vkdev->info.subgroup_size()));
@@ -642,21 +542,46 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
         local_size_x = (int)vkdev->info.subgroup_size();
     }
 
-    int max_invocation_count = buffer_size / elemsize;
+    int M = 1;
+    int N = 1;
+    int K = 1;
     if (packing_type == 256)
     {
         if (vkdev->info.support_cooperative_matrix_16_16_16())
-            max_invocation_count = max_invocation_count / 256 * local_size_x;
-        else // if (vkdev->info.support_cooperative_matrix_8_8_16())
-            max_invocation_count = max_invocation_count / 64 * local_size_x;
+        {
+            M = 16;
+            N = 16;
+            K = 16;
+        }
+        else if (vkdev->info.support_cooperative_matrix_16_8_16())
+        {
+            M = 16;
+            N = 8;
+            K = 16;
+        }
+        else if (vkdev->info.support_cooperative_matrix_8_8_16())
+        {
+            M = 8;
+            N = 8;
+            K = 16;
+        }
+        else if (vkdev->info.support_cooperative_matrix_16_8_8())
+        {
+            M = 16;
+            N = 8;
+            K = 8;
+        }
     }
-    else
+
+    int max_invocation_count = buffer_size / elemsize;
+    if (packing_type == 256)
     {
-        max_invocation_count /= packing_type;
+        max_invocation_count = max_invocation_count / (M * N) * local_size_x;
     }
 
     double max_gflops = 0;
 
+    // start with little works
     int invocation_count = max_invocation_count / 32;
     int loop = 16;
 
@@ -678,7 +603,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
             // glsl to spirv
             // -1 for omit the tail '\0'
             std::vector<uint32_t> spirv;
-            if (storage_type == 2)
+            if (arithmetic_type == 2)
             {
                 if (packing_type == 1)
                 {
@@ -689,7 +614,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     ncnn::compile_spirv_module(glsl_fp64_p4_data, sizeof(glsl_fp64_p4_data) - 1, opt, spirv);
                 }
             }
-            else if (storage_type == 3)
+            else if (arithmetic_type == 3)
             {
                 if (packing_type == 1)
                 {
@@ -700,7 +625,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     ncnn::compile_spirv_module(glsl_int32_p4_data, sizeof(glsl_int32_p4_data) - 1, opt, spirv);
                 }
             }
-            else if (storage_type == 4)
+            else if (arithmetic_type == 4)
             {
                 if (packing_type == 1)
                 {
@@ -711,7 +636,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     ncnn::compile_spirv_module(glsl_int16_p4_data, sizeof(glsl_int16_p4_data) - 1, opt, spirv);
                 }
             }
-            else // if (storage_type == 1)
+            else // if (arithmetic_type == 0 || arithmetic_type == 1)
             {
                 if (packing_type == 1)
                 {
@@ -723,13 +648,15 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                 }
                 if (packing_type == 256)
                 {
-                    if (vkdev->info.support_VK_KHR_cooperative_matrix() && vkdev->info.support_cooperative_matrix_16_16_16())
+                    // loop M N K
+                    specializations.resize(4);
+                    specializations[1].i = M;
+                    specializations[2].i = N;
+                    specializations[3].i = K;
+
+                    if (vkdev->info.support_VK_KHR_cooperative_matrix())
                     {
                         ncnn::compile_spirv_module(glsl_fp16_matrix_khr_data, sizeof(glsl_fp16_matrix_khr_data) - 1, opt, spirv);
-                    }
-                    else if (vkdev->info.support_VK_KHR_cooperative_matrix() && vkdev->info.support_cooperative_matrix_8_8_16())
-                    {
-                        ncnn::compile_spirv_module(glsl_fp16_matrix_khr_8_8_16_data, sizeof(glsl_fp16_matrix_khr_8_8_16_data) - 1, opt, spirv);
                     }
                     else
                     {
@@ -788,14 +715,11 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     break;
                 }
 
-                double mac = (double)invocation_count * (double)loop * 16 * 2;
+                double mac = (double)invocation_count * ((double)loop * 16 * 2 + 1); // +1 for the tail c0+c1
 
                 if (packing_type == 256)
                 {
-                    if (vkdev->info.support_cooperative_matrix_16_16_16())
-                        mac *= 256 * 16;
-                    else // if (vkdev->info.support_cooperative_matrix_8_8_16())
-                        mac *= 64 * 16;
+                    mac *= (M * N) * 16;
                     mac /= local_size_x;
                 }
                 else
@@ -852,17 +776,17 @@ int main(int argc, char** argv)
     fprintf(stderr, "device       = %s\n", ncnn::get_gpu_info(device_id).device_name());
 
     // device_id        = 0
-    // storage_type     = 0/1/2/3/4 = fp32 fp16 fp64 int32 int16
-    // arithmetic_type  = 0/1/2/3/4 = fp32 fp16 fp64 int32 int16
-    // packing_type     = 1/4/256   = scalar vec4 matrix
+    // storage_type     = 0/1/2/3/4/5/6 = fp32 fp16 fp64 int32 int16 int8 bf16
+    // arithmetic_type  = 0/1/2/3/4     = fp32 fp16 fp64 int32 int16
+    // packing_type     = 1/4/256       = scalar vec4 matrix
 
     fprintf(stderr, "\n");
     fprintf(stderr, "fp32-scalar  = %.2f GFLOPS\n", vkpeak(device_id, 0, 0, 1));
     fprintf(stderr, "fp32-vec4    = %.2f GFLOPS\n", vkpeak(device_id, 0, 0, 4));
 
     fprintf(stderr, "\n");
-    fprintf(stderr, "fp16-scalar  = %.2f GFLOPS\n", vkpeak(device_id, 1, 1, 1));
-    fprintf(stderr, "fp16-vec4    = %.2f GFLOPS\n", vkpeak(device_id, 1, 1, 4));
+    fprintf(stderr, "fp16-scalar  = %.2f GFLOPS\n", vkpeak(device_id, 0, 1, 1));
+    fprintf(stderr, "fp16-vec4    = %.2f GFLOPS\n", vkpeak(device_id, 0, 1, 4));
     fprintf(stderr, "fp16-matrix  = %.2f GFLOPS\n", vkpeak(device_id, 1, 1, 256));
 
     fprintf(stderr, "\n");

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -778,7 +778,6 @@ void main()
 static const char glsl_fp16_matrix_nv_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 #extension GL_KHR_memory_scope_semantics: require
 #extension GL_EXT_shader_explicit_arithmetic_types: require
@@ -828,7 +827,6 @@ void main()
 static const char glsl_fp16_matrix_dual_nv_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 #extension GL_KHR_memory_scope_semantics: require
 #extension GL_EXT_shader_explicit_arithmetic_types: require
@@ -880,7 +878,6 @@ void main()
 static const char glsl_fp16_matrix_khr_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 #extension GL_KHR_memory_scope_semantics: require
 #extension GL_EXT_shader_explicit_arithmetic_types: require
@@ -930,7 +927,6 @@ void main()
 static const char glsl_fp16_matrix_dual_khr_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 #extension GL_KHR_memory_scope_semantics: require
 #extension GL_EXT_shader_explicit_arithmetic_types: require
@@ -979,11 +975,209 @@ void main()
 }
 )";
 
-// 16-16-32
+static const char glsl_fp16_fp32_matrix_nv_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_NV_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    fcoopmatNV<16, gl_ScopeSubgroup, M, K> a = fcoopmatNV<16, gl_ScopeSubgroup, M, K>(float(gx));
+    fcoopmatNV<16, gl_ScopeSubgroup, K, N> b = fcoopmatNV<16, gl_ScopeSubgroup, K, N>(float(lx));
+
+    fcoopmatNV<32, gl_ScopeSubgroup, M, N> c = fcoopmatNV<32, gl_ScopeSubgroup, M, N>(float(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+    }
+
+    coopMatStoreNV(c, c_blob_data, gx, 0, false);
+}
+)";
+
+static const char glsl_fp16_fp32_matrix_dual_nv_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_NV_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    fcoopmatNV<16, gl_ScopeSubgroup, M, K> a = fcoopmatNV<16, gl_ScopeSubgroup, M, K>(float(gx));
+    fcoopmatNV<16, gl_ScopeSubgroup, K, N> b = fcoopmatNV<16, gl_ScopeSubgroup, K, N>(float(lx));
+
+    fcoopmatNV<32, gl_ScopeSubgroup, M, N> c0 = fcoopmatNV<32, gl_ScopeSubgroup, M, N>(float(gx));
+    fcoopmatNV<32, gl_ScopeSubgroup, M, N> c1 = fcoopmatNV<32, gl_ScopeSubgroup, M, N>(float(lx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, c0, b);
+        c1 = coopMatMulAddNV(a, c1, b);
+    }
+
+    c0 = c0 + c1;
+    coopMatStoreNV(c0, c_blob_data, gx, 0, false);
+}
+)";
+
+static const char glsl_fp16_fp32_matrix_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+    }
+
+    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_fp16_fp32_matrix_dual_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c0 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c1 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(lx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+    }
+
+    c0 = c0 + c1;
+    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
 static const char glsl_int8_matrix_khr_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 #extension GL_KHR_memory_scope_semantics: require
 #extension GL_EXT_shader_explicit_arithmetic_types: require
@@ -1033,7 +1227,6 @@ void main()
 static const char glsl_int8_matrix_dual_khr_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 #extension GL_KHR_memory_scope_semantics: require
 #extension GL_EXT_shader_explicit_arithmetic_types: require
@@ -1107,7 +1300,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
     {
         return 0;
     }
-    if (!vkdev->info.support_int8_arithmetic() && arithmetic_type == 6)
+    if (!vkdev->info.support_int8_arithmetic() && arithmetic_type == 5)
     {
         return 0;
     }
@@ -1172,39 +1365,153 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
     int M = 1;
     int N = 1;
     int K = 1;
+    bool use_fp16_fp32_matrix = false;
     if (packing_type == 256)
     {
-        if (vkdev->info.support_cooperative_matrix_16_16_16())
+        bool mnk_found = false;
+
+        if (arithmetic_type == 1)
         {
-            M = 16;
-            N = 16;
-            K = 16;
-        }
-        else if (vkdev->info.support_cooperative_matrix_16_8_16())
-        {
-            M = 16;
-            N = 8;
-            K = 16;
-        }
-        else if (vkdev->info.support_cooperative_matrix_8_8_16())
-        {
-            M = 8;
-            N = 8;
-            K = 16;
-        }
-        else if (vkdev->info.support_cooperative_matrix_16_8_8())
-        {
-            M = 16;
-            N = 8;
-            K = 8;
+            if (vkdev->info.support_VK_KHR_cooperative_matrix())
+            {
+                const std::vector<VkCooperativeMatrixPropertiesKHR>& properties = vkdev->info.queryCooperativeMatrixProperties();
+
+                {
+                    // find fp16 * fp16 => fp16
+                    for (uint32_t j = 0; j < properties.size(); j++)
+                    {
+                        const VkCooperativeMatrixPropertiesKHR& cmp = properties[j];
+
+                        if (cmp.AType == VK_COMPONENT_TYPE_FLOAT16_KHR && cmp.BType == VK_COMPONENT_TYPE_FLOAT16_KHR
+                            && cmp.CType == VK_COMPONENT_TYPE_FLOAT16_KHR && cmp.ResultType == VK_COMPONENT_TYPE_FLOAT16_KHR
+                            && cmp.scope == VK_SCOPE_SUBGROUP_KHR)
+                        {
+                            M = cmp.MSize;
+                            N = cmp.NSize;
+                            K = cmp.KSize;
+                            mnk_found = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!mnk_found)
+                {
+                    // find fp16 * fp16 => fp32
+                    for (uint32_t j = 0; j < properties.size(); j++)
+                    {
+                        const VkCooperativeMatrixPropertiesKHR& cmp = properties[j];
+
+                        if (cmp.AType == VK_COMPONENT_TYPE_FLOAT16_KHR && cmp.BType == VK_COMPONENT_TYPE_FLOAT16_KHR
+                            && cmp.CType == VK_COMPONENT_TYPE_FLOAT32_KHR && cmp.ResultType == VK_COMPONENT_TYPE_FLOAT32_KHR
+                            && cmp.scope == VK_SCOPE_SUBGROUP_KHR)
+                        {
+                            M = cmp.MSize;
+                            N = cmp.NSize;
+                            K = cmp.KSize;
+                            mnk_found = true;
+                            use_fp16_fp32_matrix = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            else // if (vkdev->info.support_VK_NV_cooperative_matrix())
+            {
+                const std::vector<VkCooperativeMatrixPropertiesNV>& properties = vkdev->info.queryCooperativeMatrixPropertiesNV();
+
+                {
+                    // find fp16 * fp16 => fp16
+                    for (uint32_t j = 0; j < properties.size(); j++)
+                    {
+                        const VkCooperativeMatrixPropertiesNV& cmp = properties[j];
+
+                        if (cmp.AType == VK_COMPONENT_TYPE_FLOAT16_NV && cmp.BType == VK_COMPONENT_TYPE_FLOAT16_NV
+                            && cmp.CType == VK_COMPONENT_TYPE_FLOAT16_NV && cmp.DType == VK_COMPONENT_TYPE_FLOAT16_NV
+                            && cmp.scope == VK_SCOPE_SUBGROUP_NV)
+                        {
+                            M = cmp.MSize;
+                            N = cmp.NSize;
+                            K = cmp.KSize;
+                            mnk_found = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!mnk_found)
+                {
+                    // find fp16 * fp16 => fp32
+                    for (uint32_t j = 0; j < properties.size(); j++)
+                    {
+                        const VkCooperativeMatrixPropertiesNV& cmp = properties[j];
+
+                        if (cmp.AType == VK_COMPONENT_TYPE_FLOAT16_NV && cmp.BType == VK_COMPONENT_TYPE_FLOAT16_NV
+                            && cmp.CType == VK_COMPONENT_TYPE_FLOAT32_NV && cmp.DType == VK_COMPONENT_TYPE_FLOAT32_NV
+                            && cmp.scope == VK_SCOPE_SUBGROUP_NV)
+                        {
+                            M = cmp.MSize;
+                            N = cmp.NSize;
+                            K = cmp.KSize;
+                            mnk_found = true;
+                            use_fp16_fp32_matrix = true;
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
-        if (arithmetic_type == 6)
+        if (arithmetic_type == 5)
         {
-            // HACK
-            M = 16;
-            N = 16;
-            K = 32;
+            if (vkdev->info.support_VK_KHR_cooperative_matrix())
+            {
+                const std::vector<VkCooperativeMatrixPropertiesKHR>& properties = vkdev->info.queryCooperativeMatrixProperties();
+
+                // find int8 * int8 => int32
+                for (uint32_t j = 0; j < properties.size(); j++)
+                {
+                    const VkCooperativeMatrixPropertiesKHR& cmp = properties[j];
+
+                    if (cmp.AType == VK_COMPONENT_TYPE_SINT8_KHR && cmp.BType == VK_COMPONENT_TYPE_SINT8_KHR
+                        && cmp.CType == VK_COMPONENT_TYPE_SINT32_KHR && cmp.ResultType == VK_COMPONENT_TYPE_SINT32_KHR
+                        && cmp.scope == VK_SCOPE_SUBGROUP_KHR)
+                    {
+                        M = cmp.MSize;
+                        N = cmp.NSize;
+                        K = cmp.KSize;
+                        mnk_found = true;
+                        break;
+                    }
+                }
+            }
+            else // if (vkdev->info.support_VK_NV_cooperative_matrix())
+            {
+                const std::vector<VkCooperativeMatrixPropertiesNV>& properties = vkdev->info.queryCooperativeMatrixPropertiesNV();
+
+                // find int8 * int8 => int32
+                for (uint32_t j = 0; j < properties.size(); j++)
+                {
+                    const VkCooperativeMatrixPropertiesNV& cmp = properties[j];
+
+                    if (cmp.AType == VK_COMPONENT_TYPE_SINT8_NV && cmp.BType == VK_COMPONENT_TYPE_SINT8_NV
+                        && cmp.CType == VK_COMPONENT_TYPE_SINT32_NV && cmp.DType == VK_COMPONENT_TYPE_SINT32_NV
+                        && cmp.scope == VK_SCOPE_SUBGROUP_NV)
+                    {
+                        M = cmp.MSize;
+                        N = cmp.NSize;
+                        K = cmp.KSize;
+                        mnk_found = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!mnk_found)
+        {
+            // no supported component type
+            return 0;
         }
     }
 
@@ -1282,7 +1589,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     ncnn::compile_spirv_module(glsl_int16_p4_dual_data, sizeof(glsl_int16_p4_dual_data) - 1, opt, spirv_dual);
                 }
             }
-            else if (arithmetic_type == 6)
+            else if (arithmetic_type == 5)
             {
                 if (packing_type == 4)
                 {
@@ -1323,13 +1630,29 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
 
                     if (vkdev->info.support_VK_KHR_cooperative_matrix())
                     {
-                        ncnn::compile_spirv_module(glsl_fp16_matrix_khr_data, sizeof(glsl_fp16_matrix_khr_data) - 1, opt, spirv);
-                        ncnn::compile_spirv_module(glsl_fp16_matrix_dual_khr_data, sizeof(glsl_fp16_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                        if (use_fp16_fp32_matrix)
+                        {
+                            ncnn::compile_spirv_module(glsl_fp16_fp32_matrix_khr_data, sizeof(glsl_fp16_fp32_matrix_khr_data) - 1, opt, spirv);
+                            ncnn::compile_spirv_module(glsl_fp16_fp32_matrix_dual_khr_data, sizeof(glsl_fp16_fp32_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                        }
+                        else
+                        {
+                            ncnn::compile_spirv_module(glsl_fp16_matrix_khr_data, sizeof(glsl_fp16_matrix_khr_data) - 1, opt, spirv);
+                            ncnn::compile_spirv_module(glsl_fp16_matrix_dual_khr_data, sizeof(glsl_fp16_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                        }
                     }
                     else
                     {
-                        ncnn::compile_spirv_module(glsl_fp16_matrix_nv_data, sizeof(glsl_fp16_matrix_nv_data) - 1, opt, spirv);
-                        ncnn::compile_spirv_module(glsl_fp16_matrix_dual_nv_data, sizeof(glsl_fp16_matrix_dual_nv_data) - 1, opt, spirv_dual);
+                        if (use_fp16_fp32_matrix)
+                        {
+                            ncnn::compile_spirv_module(glsl_fp16_fp32_matrix_nv_data, sizeof(glsl_fp16_fp32_matrix_nv_data) - 1, opt, spirv);
+                            ncnn::compile_spirv_module(glsl_fp16_fp32_matrix_dual_nv_data, sizeof(glsl_fp16_fp32_matrix_dual_nv_data) - 1, opt, spirv_dual);
+                        }
+                        else
+                        {
+                            ncnn::compile_spirv_module(glsl_fp16_matrix_nv_data, sizeof(glsl_fp16_matrix_nv_data) - 1, opt, spirv);
+                            ncnn::compile_spirv_module(glsl_fp16_matrix_dual_nv_data, sizeof(glsl_fp16_matrix_dual_nv_data) - 1, opt, spirv_dual);
+                        }
                     }
                 }
             }
@@ -1508,8 +1831,12 @@ int main(int argc, char** argv)
     fprintf(stderr, "int16-vec4   = %.2f GIOPS\n", vkpeak(device_id, 3, 4, 4));
 
     fprintf(stderr, "\n");
-    fprintf(stderr, "int8-dotprod = %.2f GIOPS\n", vkpeak(device_id, 3, 6, 4));
-    fprintf(stderr, "int8-matrix  = %.2f GIOPS\n", vkpeak(device_id, 3, 6, 256));
+    fprintf(stderr, "int8-dotprod = %.2f GIOPS\n", vkpeak(device_id, 3, 5, 4));
+    fprintf(stderr, "int8-matrix  = %.2f GIOPS\n", vkpeak(device_id, 3, 5, 256));
+
+    // fprintf(stderr, "\n");
+    // fprintf(stderr, "bf16-dotprod = %.2f GFLOPS\n", vkpeak(device_id, 3, 6, 4));
+    // fprintf(stderr, "bf16-matrix  = %.2f GFLOPS\n", vkpeak(device_id, 3, 6, 256));
 
     ncnn::destroy_gpu_instance();
 

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -688,7 +688,6 @@ void main()
 static const char glsl_int8_p4_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_explicit_arithmetic_types_int8: require
 #extension GL_EXT_integer_dot_product: require
 
 layout (constant_id = 0) const int loop = 1;
@@ -702,27 +701,27 @@ void main()
 
     int c = int(gx);
 
-    i8vec4 a = i8vec4(gx) + i8vec4(0,1,2,-3);
-    i8vec4 b = i8vec4(lx) + i8vec4(2,3,5,-7);
+    int a = int(gx);
+    int b = int(lx);
 
     for (int i = 0; i < loop; i++)
     {
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
-        c = dotAccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
+        c = dotPacked4x8AccSatEXT(a, b, c);
     }
 
     c_blob_data[gx] = c;
@@ -732,7 +731,6 @@ void main()
 static const char glsl_int8_p4_dual_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_explicit_arithmetic_types_int8: require
 #extension GL_EXT_integer_dot_product: require
 
 layout (constant_id = 0) const int loop = 1;
@@ -747,27 +745,27 @@ void main()
     int c0 = int(gx);
     int c1 = int(lx);
 
-    i8vec4 a = i8vec4(gx) + i8vec4(0,1,2,-3);
-    i8vec4 b = i8vec4(lx) + i8vec4(2,3,5,-7);
+    int a = int(gx);
+    int b = int(lx);
 
     for (int i = 0; i < loop; i++)
     {
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
-        c0 = dotAccSatEXT(a, b, c0);
-        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
+        c0 = dotPacked4x8AccSatEXT(a, b, c0);
+        c1 = dotPacked4x8AccSatEXT(a, b, c1);
     }
 
     c0 = c0 + c1;

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -991,7 +991,7 @@ void main()
     }
 
     c0 = c0 + c1;
-    coopMatStoreNV(c, c_blob_data, gx * (M * N) / 2, N / 2, false);
+    coopMatStoreNV(c0, c_blob_data, gx * (M * N) / 2, N / 2, false);
 }
 )";
 

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -775,6 +775,96 @@ void main()
 }
 )";
 
+static const char glsl_bf16_p4_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+#extension GL_EXT_bfloat16: require
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    float c = float(gx);
+
+    bf16vec4 a = bf16vec4(bfloat16_t(gx + vec4(0,1,2,-3)));
+    bf16vec4 b = bf16vec4(bfloat16_t(lx + vec4(2,3,5,-7)));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+        c = float(dot(a, b)) + c;
+    }
+
+    c_blob_data[gx] = c;
+}
+)";
+
+static const char glsl_bf16_p4_dual_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types : require
+#extension GL_EXT_bfloat16: require
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    float c0 = float(gx);
+    float c1 = float(lx);
+
+    bf16vec4 a = bf16vec4(bfloat16_t(gx + vec4(0,1,2,-3)));
+    bf16vec4 b = bf16vec4(bfloat16_t(lx + vec4(2,3,5,-7)));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+        c0 = float(dot(a, b)) + c0;
+        c1 = float(dot(a, b)) + c1;
+    }
+
+    c0 = c0 + c1;
+    c_blob_data[gx] = c0;
+}
+)";
+
 static const char glsl_fp16_matrix_nv_data[] = R"(
 #version 450
 
@@ -1275,6 +1365,213 @@ void main()
 }
 )";
 
+static const char glsl_bf16_matrix_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+#extension GL_EXT_bfloat16: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c = coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+    }
+
+    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_bf16_matrix_dual_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+#extension GL_EXT_bfloat16: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c0 = coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c1 = coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(lx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+    }
+
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c2 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(c0);
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c3 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(c1);
+
+    c0 = coopmat<bfloat16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(c2 + c3);
+    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_bf16_fp32_matrix_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+#extension GL_EXT_bfloat16: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+    }
+
+    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_bf16_fp32_matrix_dual_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+#extension GL_EXT_bfloat16: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<bfloat16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<bfloat16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c0 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+    coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c1 = coopmat<float, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(lx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+    }
+
+    c0 = c0 + c1;
+    coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
 static double vkpeak(int device_id, int storage_type, int arithmetic_type, int packing_type)
 {
     ncnn::VulkanDevice* vkdev = ncnn::get_gpu_device(device_id);
@@ -1304,6 +1601,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
     {
         return 0;
     }
+    // TODO check arithmetic_type == 6 for bf16
     if (!vkdev->info.support_cooperative_matrix() && packing_type == 256)
     {
         return 0;
@@ -1366,6 +1664,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
     int N = 1;
     int K = 1;
     bool use_fp16_fp32_matrix = false;
+    bool use_bf16_fp32_matrix = false;
     if (packing_type == 256)
     {
         bool mnk_found = false;
@@ -1508,6 +1807,60 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
             }
         }
 
+        if (arithmetic_type == 6)
+        {
+            if (vkdev->info.support_VK_KHR_cooperative_matrix())
+            {
+                const std::vector<VkCooperativeMatrixPropertiesKHR>& properties = vkdev->info.queryCooperativeMatrixProperties();
+
+                {
+                    // find bf16 * bf16 => bf16
+                    for (uint32_t j = 0; j < properties.size(); j++)
+                    {
+                        const VkCooperativeMatrixPropertiesKHR& cmp = properties[j];
+
+                        if (cmp.AType == VK_COMPONENT_TYPE_BFLOAT16_KHR && cmp.BType == VK_COMPONENT_TYPE_BFLOAT16_KHR
+                            && cmp.CType == VK_COMPONENT_TYPE_BFLOAT16_KHR && cmp.ResultType == VK_COMPONENT_TYPE_BFLOAT16_KHR
+                            && cmp.scope == VK_SCOPE_SUBGROUP_KHR)
+                        {
+                            M = cmp.MSize;
+                            N = cmp.NSize;
+                            K = cmp.KSize;
+                            mnk_found = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!mnk_found)
+                {
+                    // find bf16 * bf16 => fp32
+                    for (uint32_t j = 0; j < properties.size(); j++)
+                    {
+                        const VkCooperativeMatrixPropertiesKHR& cmp = properties[j];
+
+                        if (cmp.AType == VK_COMPONENT_TYPE_BFLOAT16_KHR && cmp.BType == VK_COMPONENT_TYPE_BFLOAT16_KHR
+                            && cmp.CType == VK_COMPONENT_TYPE_FLOAT32_KHR && cmp.ResultType == VK_COMPONENT_TYPE_FLOAT32_KHR
+                            && cmp.scope == VK_SCOPE_SUBGROUP_KHR)
+                        {
+                            M = cmp.MSize;
+                            N = cmp.NSize;
+                            K = cmp.KSize;
+                            mnk_found = true;
+                            use_bf16_fp32_matrix = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // HACK
+            M = 16;
+            N = 16;
+            K = 16;
+            mnk_found = true;
+        }
+
         if (!mnk_found)
         {
             // no supported component type
@@ -1606,6 +1959,33 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
 
                     ncnn::compile_spirv_module(glsl_int8_matrix_khr_data, sizeof(glsl_int8_matrix_khr_data) - 1, opt, spirv);
                     ncnn::compile_spirv_module(glsl_int8_matrix_dual_khr_data, sizeof(glsl_int8_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                }
+            }
+            else if (arithmetic_type == 6)
+            {
+                if (packing_type == 4)
+                {
+                    ncnn::compile_spirv_module(glsl_bf16_p4_data, sizeof(glsl_bf16_p4_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_bf16_p4_dual_data, sizeof(glsl_bf16_p4_dual_data) - 1, opt, spirv_dual);
+                }
+                if (packing_type == 256)
+                {
+                    // loop M N K
+                    specializations.resize(4);
+                    specializations[1].i = M;
+                    specializations[2].i = N;
+                    specializations[3].i = K;
+
+                    if (use_bf16_fp32_matrix)
+                    {
+                        ncnn::compile_spirv_module(glsl_bf16_fp32_matrix_khr_data, sizeof(glsl_bf16_fp32_matrix_khr_data) - 1, opt, spirv);
+                        ncnn::compile_spirv_module(glsl_bf16_fp32_matrix_dual_khr_data, sizeof(glsl_bf16_fp32_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                    }
+                    else
+                    {
+                        ncnn::compile_spirv_module(glsl_bf16_matrix_khr_data, sizeof(glsl_bf16_matrix_khr_data) - 1, opt, spirv);
+                        ncnn::compile_spirv_module(glsl_bf16_matrix_dual_khr_data, sizeof(glsl_bf16_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                    }
                 }
             }
             else // if (arithmetic_type == 0 || arithmetic_type == 1)
@@ -1834,9 +2214,9 @@ int main(int argc, char** argv)
     fprintf(stderr, "int8-dotprod = %.2f GIOPS\n", vkpeak(device_id, 3, 5, 4));
     fprintf(stderr, "int8-matrix  = %.2f GIOPS\n", vkpeak(device_id, 3, 5, 256));
 
-    // fprintf(stderr, "\n");
-    // fprintf(stderr, "bf16-dotprod = %.2f GFLOPS\n", vkpeak(device_id, 3, 6, 4));
-    // fprintf(stderr, "bf16-matrix  = %.2f GFLOPS\n", vkpeak(device_id, 3, 6, 256));
+    fprintf(stderr, "\n");
+    fprintf(stderr, "bf16-dotprod = %.2f GFLOPS\n", vkpeak(device_id, 0, 6, 4));
+    fprintf(stderr, "bf16-matrix  = %.2f GFLOPS\n", vkpeak(device_id, 0, 6, 256));
 
     ncnn::destroy_gpu_instance();
 

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -2026,7 +2026,10 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
     max_invocation_count = std::max(max_invocation_count / local_size_x, 1) * local_size_x;
     if (packing_type == 256)
     {
-        max_invocation_count = std::max(max_invocation_count / (M * N), 1);
+        if (use_fp16_fp32_matrix || use_bf16_fp32_matrix)
+            max_invocation_count = std::max(max_invocation_count / (M * N) / 2, 1);
+        else
+            max_invocation_count = std::max(max_invocation_count / (M * N), 1);
     }
 
     double max_gflops = 0;

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -892,22 +892,22 @@ void main()
 
     for (int i = 0; i < loop; i++)
     {
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
     }
 
     coopMatStoreNV(c, c_blob_data, gx, 0, false);
@@ -942,22 +942,22 @@ void main()
 
     for (int i = 0; i < loop; i++)
     {
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
     }
 
     c0 = c0 + c1;
@@ -1092,22 +1092,22 @@ void main()
 
     for (int i = 0; i < loop; i++)
     {
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
-        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
     }
 
     coopMatStoreNV(c, c_blob_data, gx, 0, false);
@@ -1142,22 +1142,22 @@ void main()
 
     for (int i = 0; i < loop; i++)
     {
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
-        c0 = coopMatMulAddNV(a, c0, b);
-        c1 = coopMatMulAddNV(a, c1, b);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
     }
 
     c0 = c0 + c1;
@@ -1262,6 +1262,108 @@ void main()
 
     c0 = c0 + c1;
     coopMatStore(c0, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_int8_matrix_nv_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int8: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_NV_cooperative_matrix: require
+#extension GL_NV_integer_cooperative_matrix : require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    icoopmatNV<8, gl_ScopeSubgroup, M, K> a = icoopmatNV<8, gl_ScopeSubgroup, M, K>(int8_t(gx));
+    icoopmatNV<8, gl_ScopeSubgroup, K, N> b = icoopmatNV<8, gl_ScopeSubgroup, K, N>(int8_t(lx));
+
+    icoopmatNV<32, gl_ScopeSubgroup, M, N> c = icoopmatNV<32, gl_ScopeSubgroup, M, N>(int(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+        c = coopMatMulAddNV(a, b, c);
+    }
+
+    coopMatStoreNV(c, c_blob_data, gx * (M * N), 0, false);
+}
+)";
+
+static const char glsl_int8_matrix_dual_nv_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int8: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_NV_cooperative_matrix: require
+#extension GL_NV_integer_cooperative_matrix : require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    icoopmatNV<8, gl_ScopeSubgroup, M, K> a = icoopmatNV<8, gl_ScopeSubgroup, M, K>(int8_t(gx));
+    icoopmatNV<8, gl_ScopeSubgroup, K, N> b = icoopmatNV<8, gl_ScopeSubgroup, K, N>(int8_t(lx));
+
+    icoopmatNV<32, gl_ScopeSubgroup, M, N> c0 = icoopmatNV<32, gl_ScopeSubgroup, M, N>(int(gx));
+    icoopmatNV<32, gl_ScopeSubgroup, M, N> c1 = icoopmatNV<32, gl_ScopeSubgroup, M, N>(int(lx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+        c0 = coopMatMulAddNV(a, b, c0);
+        c1 = coopMatMulAddNV(a, b, c1);
+    }
+
+    c0 = c0 + c1;
+    coopMatStoreNV(c0, c_blob_data, gx * (M * N), 0, false);
 }
 )";
 
@@ -1957,8 +2059,16 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     specializations[2].i = N;
                     specializations[3].i = K;
 
-                    ncnn::compile_spirv_module(glsl_int8_matrix_khr_data, sizeof(glsl_int8_matrix_khr_data) - 1, opt, spirv);
-                    ncnn::compile_spirv_module(glsl_int8_matrix_dual_khr_data, sizeof(glsl_int8_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                    if (vkdev->info.support_VK_KHR_cooperative_matrix())
+                    {
+                        ncnn::compile_spirv_module(glsl_int8_matrix_khr_data, sizeof(glsl_int8_matrix_khr_data) - 1, opt, spirv);
+                        ncnn::compile_spirv_module(glsl_int8_matrix_dual_khr_data, sizeof(glsl_int8_matrix_dual_khr_data) - 1, opt, spirv_dual);
+                    }
+                    else
+                    {
+                        ncnn::compile_spirv_module(glsl_int8_matrix_nv_data, sizeof(glsl_int8_matrix_nv_data) - 1, opt, spirv);
+                        ncnn::compile_spirv_module(glsl_int8_matrix_dual_nv_data, sizeof(glsl_int8_matrix_dual_nv_data) - 1, opt, spirv_dual);
+                    }
                 }
             }
             else if (arithmetic_type == 6)

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -2012,12 +2012,6 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     }
                 }
             }
-
-            // HACK
-            M = 16;
-            N = 16;
-            K = 16;
-            mnk_found = true;
         }
 
         if (!mnk_found)

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -17,6 +17,47 @@ void main()
     const uint gx = gl_GlobalInvocationID.x;
     const uint lx = gl_LocalInvocationID.x;
 
+    afp c = afp(gx);
+
+    afp a = c;
+    afp b = afp(lx);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = sfp(c);
+}
+)";
+
+static const char glsl_p1_dual_data[] = R"(
+#version 450
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
     afp c0 = afp(gx);
     afp c1 = afp(lx);
 
@@ -45,6 +86,47 @@ void main()
 
     c0 = c0 + c1;
     c_blob_data[gx] = sfp(c0);
+}
+)";
+
+static const char glsl_p4_dual_data[] = R"(
+#version 450
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { float c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    afpvec4 c = afpvec4(gx);
+
+    afpvec4 a = c + afpvec4(0,1,2,-3);
+    afpvec4 b = afpvec4(lx) + afpvec4(2,3,5,-7);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = sfp((c[0] + c[1]) + (c[2] + c[3]));
 }
 )";
 
@@ -103,6 +185,47 @@ void main()
     const uint gx = gl_GlobalInvocationID.x;
     const uint lx = gl_LocalInvocationID.x;
 
+    double c = double(gx);
+
+    double a = c;
+    double b = double(lx);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = c;
+}
+)";
+
+static const char glsl_fp64_p1_dual_data[] = R"(
+#version 450
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { double c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
     double c0 = double(gx);
     double c1 = double(lx);
 
@@ -135,6 +258,47 @@ void main()
 )";
 
 static const char glsl_fp64_p4_data[] = R"(
+#version 450
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { double c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    dvec4 c = dvec4(gx);
+
+    dvec4 a = c + dvec4(0,1,2,-3);
+    dvec4 b = dvec4(lx) + dvec4(2,3,5,-7);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = (c[0] + c[1]) + (c[2] + c[3]);
+}
+)";
+
+static const char glsl_fp64_p4_dual_data[] = R"(
 #version 450
 
 layout (constant_id = 0) const int loop = 1;
@@ -189,6 +353,47 @@ void main()
     const uint gx = gl_GlobalInvocationID.x;
     const uint lx = gl_LocalInvocationID.x;
 
+    int c = int(gx);
+
+    int a = c;
+    int b = int(lx);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = c;
+}
+)";
+
+static const char glsl_int32_p1_dual_data[] = R"(
+#version 450
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
     int c0 = int(gx);
     int c1 = int(lx);
 
@@ -221,6 +426,47 @@ void main()
 )";
 
 static const char glsl_int32_p4_data[] = R"(
+#version 450
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    ivec4 c = ivec4(gx);
+
+    ivec4 a = c + ivec4(0,1,2,-3);
+    ivec4 b = ivec4(lx) + ivec4(2,3,5,-7);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = (c[0] + c[1]) + (c[2] + c[3]);
+}
+)";
+
+static const char glsl_int32_p4_dual_data[] = R"(
 #version 450
 
 layout (constant_id = 0) const int loop = 1;
@@ -266,12 +512,54 @@ void main()
 static const char glsl_int16_p1_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16: require
 
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { int16_t c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    int16_t c = int16_t(gx);
+
+    int16_t a = c;
+    int16_t b = int16_t(lx);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = int(c);
+}
+)";
+
+static const char glsl_int16_p1_dual_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int16: require
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
 
 void main()
 {
@@ -305,19 +593,61 @@ void main()
     }
 
     c0 = c0 + c1;
-    c_blob_data[gx] = c0;
+    c_blob_data[gx] = int(c0);
 }
 )";
 
 static const char glsl_int16_p4_data[] = R"(
 #version 450
 
-#extension GL_EXT_shader_16bit_storage: require
 #extension GL_EXT_shader_explicit_arithmetic_types_int16: require
 
 layout (constant_id = 0) const int loop = 1;
 
-layout (binding = 0) writeonly buffer c_blob { int16_t c_blob_data[]; };
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    i16vec4 c = i16vec4(gx);
+
+    i16vec4 a = c + i16vec4(0,1,2,-3);
+    i16vec4 b = i16vec4(lx) + i16vec4(2,3,5,-7);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+        c = a * c + b;
+    }
+
+    c_blob_data[gx] = int((c[0] + c[1]) + (c[2] + c[3]));
+}
+)";
+
+static const char glsl_int16_p4_dual_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int16: require
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
 
 void main()
 {
@@ -351,11 +681,151 @@ void main()
     }
 
     c0 = c0 + c1;
-    c_blob_data[gx] = (c0[0] + c0[1]) + (c0[2] + c0[3]);
+    c_blob_data[gx] = int((c0[0] + c0[1]) + (c0[2] + c0[3]));
+}
+)";
+
+static const char glsl_int8_p4_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int8: require
+#extension GL_EXT_integer_dot_product: require
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    int c = int(gx);
+
+    i8vec4 a = i8vec4(gx) + i8vec4(0,1,2,-3);
+    i8vec4 b = i8vec4(lx) + i8vec4(2,3,5,-7);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+        c = dotAccSatEXT(a, b, c);
+    }
+
+    c_blob_data[gx] = c;
+}
+)";
+
+static const char glsl_int8_p4_dual_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_explicit_arithmetic_types_int8: require
+#extension GL_EXT_integer_dot_product: require
+
+layout (constant_id = 0) const int loop = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    int c0 = int(gx);
+    int c1 = int(lx);
+
+    i8vec4 a = i8vec4(gx) + i8vec4(0,1,2,-3);
+    i8vec4 b = i8vec4(lx) + i8vec4(2,3,5,-7);
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+        c0 = dotAccSatEXT(a, b, c0);
+        c1 = dotAccSatEXT(a, b, c1);
+    }
+
+    c0 = c0 + c1;
+    c_blob_data[gx] = c0;
 }
 )";
 
 static const char glsl_fp16_matrix_nv_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_16bit_storage: require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_NV_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    fcoopmatNV<16, gl_ScopeSubgroup, M, K> a = fcoopmatNV<16, gl_ScopeSubgroup, M, K>(float(gx));
+    fcoopmatNV<16, gl_ScopeSubgroup, K, N> b = fcoopmatNV<16, gl_ScopeSubgroup, K, N>(float(lx));
+
+    fcoopmatNV<16, gl_ScopeSubgroup, M, N> c = fcoopmatNV<16, gl_ScopeSubgroup, M, N>(float(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+        c = coopMatMulAddNV(a, c, b);
+    }
+
+    coopMatStoreNV(c, c_blob_data, gx, 0, false);
+}
+)";
+
+static const char glsl_fp16_matrix_dual_nv_data[] = R"(
 #version 450
 
 #extension GL_EXT_shader_16bit_storage: require
@@ -431,6 +901,56 @@ void main()
     coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
     coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
 
+    coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+    }
+
+    coopMatStore(c, c_blob_data, gx, 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_fp16_matrix_dual_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_16bit_storage: require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { uvec4 c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<float16_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(float(gx));
+    coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<float16_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(float(lx));
+
     coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c0 = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(gx));
     coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c1 = coopmat<float16_t, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(float(lx));
 
@@ -459,6 +979,109 @@ void main()
 }
 )";
 
+// 16-16-32
+static const char glsl_int8_matrix_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_16bit_storage: require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<int8_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<int8_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(int8_t(gx));
+    coopmat<int8_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<int8_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(int8_t(lx));
+
+    coopmat<int, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c = coopmat<int, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(int(gx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+        c = coopMatMulAdd(a, b, c);
+    }
+
+    coopMatStore(c, c_blob_data, gx * (M * N), 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
+static const char glsl_int8_matrix_dual_khr_data[] = R"(
+#version 450
+
+#extension GL_EXT_shader_16bit_storage: require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
+#extension GL_KHR_memory_scope_semantics: require
+#extension GL_EXT_shader_explicit_arithmetic_types: require
+#extension GL_KHR_cooperative_matrix: require
+
+layout (constant_id = 0) const int loop = 1;
+layout (constant_id = 1) const int M = 1;
+layout (constant_id = 2) const int N = 1;
+layout (constant_id = 3) const int K = 1;
+
+layout (binding = 0) writeonly buffer c_blob { int c_blob_data[]; };
+
+void main()
+{
+    const uint gx = gl_GlobalInvocationID.x;
+    const uint lx = gl_LocalInvocationID.x;
+
+    coopmat<int8_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA> a = coopmat<int8_t, gl_ScopeSubgroup, M, K, gl_MatrixUseA>(int8_t(gx));
+    coopmat<int8_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB> b = coopmat<int8_t, gl_ScopeSubgroup, K, N, gl_MatrixUseB>(int8_t(lx));
+
+    coopmat<int, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c0 = coopmat<int, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(int(gx));
+    coopmat<int, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator> c1 = coopmat<int, gl_ScopeSubgroup, M, N, gl_MatrixUseAccumulator>(int(lx));
+
+    for (int i = 0; i < loop; i++)
+    {
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+        c0 = coopMatMulAdd(a, b, c0);
+        c1 = coopMatMulAdd(a, b, c1);
+    }
+
+    c0 = c0 + c1;
+    coopMatStore(c0, c_blob_data, gx * (M * N), 0, gl_CooperativeMatrixLayoutRowMajor);
+}
+)";
+
 static double vkpeak(int device_id, int storage_type, int arithmetic_type, int packing_type)
 {
     ncnn::VulkanDevice* vkdev = ncnn::get_gpu_device(device_id);
@@ -484,7 +1107,11 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
     {
         return 0;
     }
-    if (!vkdev->info.support_cooperative_matrix_16_16_16() && !vkdev->info.support_cooperative_matrix_8_8_16() && packing_type == 256)
+    if (!vkdev->info.support_int8_arithmetic() && arithmetic_type == 6)
+    {
+        return 0;
+    }
+    if (!vkdev->info.support_cooperative_matrix() && packing_type == 256)
     {
         return 0;
     }
@@ -504,12 +1131,12 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
 
     ncnn::VkAllocator* allocator = vkdev->acquire_blob_allocator();
 
-    // reuse c storage, max 1G
-    int buffer_size = std::min((int)(vkdev->get_heap_budget() / 8), 1 * 1024) * 1024 * 1024;
+    // reuse c storage, max 512M
+    int buffer_size = std::min((int)(vkdev->get_heap_budget() / 8), 512) * 1024 * 1024;
     if (vkdev->info.type() == 1)
     {
-        // max 256M for integrated gpu
-        buffer_size = std::min(buffer_size, 256 * 1024 * 1024);
+        // max 128M for integrated gpu
+        buffer_size = std::min(buffer_size, 128 * 1024 * 1024);
     }
     ncnn::VkMat c(buffer_size, (size_t)1u, 1, allocator);
 
@@ -571,18 +1198,28 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
             N = 8;
             K = 8;
         }
+
+        if (arithmetic_type == 6)
+        {
+            // HACK
+            M = 16;
+            N = 16;
+            K = 32;
+        }
     }
 
     int max_invocation_count = buffer_size / elemsize;
+    // make max_invocation_count be multiple of local_size_x
+    max_invocation_count = std::max(max_invocation_count / local_size_x, 1) * local_size_x;
     if (packing_type == 256)
     {
-        max_invocation_count = max_invocation_count / (M * N) * local_size_x;
+        max_invocation_count = std::max(max_invocation_count / (M * N), 1);
     }
 
     double max_gflops = 0;
 
     // start with little works
-    int invocation_count = max_invocation_count / 32;
+    int invocation_count = std::max(max_invocation_count / 32, 8);
     int loop = 16;
 
     bool rerun = true;
@@ -594,8 +1231,10 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
 
         // setup pipeline
         ncnn::Pipeline pipeline(vkdev);
+        ncnn::Pipeline pipeline_dual(vkdev);
         {
             pipeline.set_local_size_xyz(local_size_x, 1, 1);
+            pipeline_dual.set_local_size_xyz(local_size_x, 1, 1);
 
             std::vector<ncnn::vk_specialization_type> specializations(1);
             specializations[0].i = loop;
@@ -603,15 +1242,18 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
             // glsl to spirv
             // -1 for omit the tail '\0'
             std::vector<uint32_t> spirv;
+            std::vector<uint32_t> spirv_dual;
             if (arithmetic_type == 2)
             {
                 if (packing_type == 1)
                 {
                     ncnn::compile_spirv_module(glsl_fp64_p1_data, sizeof(glsl_fp64_p1_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_fp64_p1_dual_data, sizeof(glsl_fp64_p1_dual_data) - 1, opt, spirv_dual);
                 }
                 if (packing_type == 4)
                 {
                     ncnn::compile_spirv_module(glsl_fp64_p4_data, sizeof(glsl_fp64_p4_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_fp64_p4_dual_data, sizeof(glsl_fp64_p4_dual_data) - 1, opt, spirv_dual);
                 }
             }
             else if (arithmetic_type == 3)
@@ -619,10 +1261,12 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                 if (packing_type == 1)
                 {
                     ncnn::compile_spirv_module(glsl_int32_p1_data, sizeof(glsl_int32_p1_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_int32_p1_dual_data, sizeof(glsl_int32_p1_dual_data) - 1, opt, spirv_dual);
                 }
                 if (packing_type == 4)
                 {
                     ncnn::compile_spirv_module(glsl_int32_p4_data, sizeof(glsl_int32_p4_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_int32_p4_dual_data, sizeof(glsl_int32_p4_dual_data) - 1, opt, spirv_dual);
                 }
             }
             else if (arithmetic_type == 4)
@@ -630,10 +1274,31 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                 if (packing_type == 1)
                 {
                     ncnn::compile_spirv_module(glsl_int16_p1_data, sizeof(glsl_int16_p1_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_int16_p1_dual_data, sizeof(glsl_int16_p1_dual_data) - 1, opt, spirv_dual);
                 }
                 if (packing_type == 4)
                 {
                     ncnn::compile_spirv_module(glsl_int16_p4_data, sizeof(glsl_int16_p4_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_int16_p4_dual_data, sizeof(glsl_int16_p4_dual_data) - 1, opt, spirv_dual);
+                }
+            }
+            else if (arithmetic_type == 6)
+            {
+                if (packing_type == 4)
+                {
+                    ncnn::compile_spirv_module(glsl_int8_p4_data, sizeof(glsl_int8_p4_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_int8_p4_dual_data, sizeof(glsl_int8_p4_dual_data) - 1, opt, spirv_dual);
+                }
+                if (packing_type == 256)
+                {
+                    // loop M N K
+                    specializations.resize(4);
+                    specializations[1].i = M;
+                    specializations[2].i = N;
+                    specializations[3].i = K;
+
+                    ncnn::compile_spirv_module(glsl_int8_matrix_khr_data, sizeof(glsl_int8_matrix_khr_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_int8_matrix_dual_khr_data, sizeof(glsl_int8_matrix_dual_khr_data) - 1, opt, spirv_dual);
                 }
             }
             else // if (arithmetic_type == 0 || arithmetic_type == 1)
@@ -641,10 +1306,12 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                 if (packing_type == 1)
                 {
                     ncnn::compile_spirv_module(glsl_p1_data, sizeof(glsl_p1_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_p1_dual_data, sizeof(glsl_p1_dual_data) - 1, opt, spirv_dual);
                 }
                 if (packing_type == 4)
                 {
                     ncnn::compile_spirv_module(glsl_p4_data, sizeof(glsl_p4_data) - 1, opt, spirv);
+                    ncnn::compile_spirv_module(glsl_p4_dual_data, sizeof(glsl_p4_dual_data) - 1, opt, spirv_dual);
                 }
                 if (packing_type == 256)
                 {
@@ -657,15 +1324,18 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     if (vkdev->info.support_VK_KHR_cooperative_matrix())
                     {
                         ncnn::compile_spirv_module(glsl_fp16_matrix_khr_data, sizeof(glsl_fp16_matrix_khr_data) - 1, opt, spirv);
+                        ncnn::compile_spirv_module(glsl_fp16_matrix_dual_khr_data, sizeof(glsl_fp16_matrix_dual_khr_data) - 1, opt, spirv_dual);
                     }
                     else
                     {
                         ncnn::compile_spirv_module(glsl_fp16_matrix_nv_data, sizeof(glsl_fp16_matrix_nv_data) - 1, opt, spirv);
+                        ncnn::compile_spirv_module(glsl_fp16_matrix_dual_nv_data, sizeof(glsl_fp16_matrix_dual_nv_data) - 1, opt, spirv_dual);
                     }
                 }
             }
 
             pipeline.create(spirv.data(), spirv.size() * 4, specializations);
+            pipeline_dual.create(spirv_dual.data(), spirv_dual.size() * 4, specializations);
         }
 
         const int cmd_loop = 10;
@@ -674,6 +1344,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
         {
             // encode command
             ncnn::VkCompute cmd(vkdev);
+            ncnn::VkCompute cmd_dual(vkdev);
             {
                 std::vector<ncnn::VkMat> bindings(1);
                 bindings[0] = c;
@@ -685,6 +1356,7 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                 dispatcher.h = 1;
                 dispatcher.c = 1;
                 cmd.record_pipeline(&pipeline, bindings, constants, dispatcher);
+                cmd_dual.record_pipeline(&pipeline_dual, bindings, constants, dispatcher);
             }
 
             // time this
@@ -698,12 +1370,24 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     return 0;
                 }
 
-                double time = ncnn::get_current_time() - t0;
+                double t1 = ncnn::get_current_time();
 
-                if (time < 800)
+                ret = cmd_dual.submit_and_wait();
+                if (ret != 0)
+                {
+                    vkdev->reclaim_blob_allocator(allocator);
+                    return 0;
+                }
+
+                double t2 = ncnn::get_current_time();
+
+                double time = t1 - t0;
+                double time_dual = t2 - t1;
+
+                if (time < 800 || time_dual < 800)
                 {
                     // for fast device
-                    if (invocation_count < max_invocation_count)
+                    if (invocation_count * 2 <= max_invocation_count)
                     {
                         invocation_count = std::min(invocation_count * 2, max_invocation_count);
                     }
@@ -715,19 +1399,41 @@ static double vkpeak(int device_id, int storage_type, int arithmetic_type, int p
                     break;
                 }
 
-                double mac = (double)invocation_count * ((double)loop * 16 * 2 + 1); // +1 for the tail c0+c1
-
-                if (packing_type == 256)
+                double gflops;
                 {
-                    mac *= (M * N) * 16;
-                    mac /= local_size_x;
+                    double mac = (double)invocation_count * ((double)loop * 16 * 2);
+
+                    if (packing_type == 256)
+                    {
+                        mac *= M * N * K;
+                        mac /= local_size_x;
+                    }
+                    else
+                    {
+                        mac *= packing_type;
+                    }
+
+                    gflops = mac / time / 1000000;
                 }
-                else
+                double gflops_dual;
                 {
-                    mac *= packing_type;
+                    // dual issue is faster
+                    double mac = (double)invocation_count * ((double)loop * 16 * 2 + 1); // +1 for the tail c0+c1
+
+                    if (packing_type == 256)
+                    {
+                        mac *= M * N * K;
+                        mac /= local_size_x;
+                    }
+                    else
+                    {
+                        mac *= packing_type;
+                    }
+
+                    gflops_dual = mac / time_dual / 1000000;
                 }
 
-                double gflops = mac / time / 1000000;
+                gflops = std::max(gflops, gflops_dual);
 
                 // fprintf(stderr, "%f gflops\n", gflops);
 
@@ -777,7 +1483,7 @@ int main(int argc, char** argv)
 
     // device_id        = 0
     // storage_type     = 0/1/2/3/4/5/6 = fp32 fp16 fp64 int32 int16 int8 bf16
-    // arithmetic_type  = 0/1/2/3/4     = fp32 fp16 fp64 int32 int16
+    // arithmetic_type  = 0/1/2/3/4/5/6 = fp32 fp16 fp64 int32 int16 int8 bf16
     // packing_type     = 1/4/256       = scalar vec4 matrix
 
     fprintf(stderr, "\n");
@@ -798,8 +1504,12 @@ int main(int argc, char** argv)
     fprintf(stderr, "int32-vec4   = %.2f GIOPS\n", vkpeak(device_id, 3, 3, 4));
 
     fprintf(stderr, "\n");
-    fprintf(stderr, "int16-scalar = %.2f GIOPS\n", vkpeak(device_id, 4, 4, 1));
-    fprintf(stderr, "int16-vec4   = %.2f GIOPS\n", vkpeak(device_id, 4, 4, 4));
+    fprintf(stderr, "int16-scalar = %.2f GIOPS\n", vkpeak(device_id, 3, 4, 1));
+    fprintf(stderr, "int16-vec4   = %.2f GIOPS\n", vkpeak(device_id, 3, 4, 4));
+
+    fprintf(stderr, "\n");
+    fprintf(stderr, "int8-dotprod = %.2f GIOPS\n", vkpeak(device_id, 3, 6, 4));
+    fprintf(stderr, "int8-matrix  = %.2f GIOPS\n", vkpeak(device_id, 3, 6, 256));
 
     ncnn::destroy_gpu_instance();
 

--- a/vkpeak.cpp
+++ b/vkpeak.cpp
@@ -790,32 +790,48 @@ void main()
     const uint gx = gl_GlobalInvocationID.x;
     const uint lx = gl_LocalInvocationID.x;
 
-    float c = float(gx);
+    bfloat16_t c = bfloat16_t(gx);
 
-    bf16vec4 a = bf16vec4(bfloat16_t(gx + vec4(0,1,2,-3)));
-    bf16vec4 b = bf16vec4(bfloat16_t(lx + vec4(2,3,5,-7)));
+    u16vec4 a = uint16_t(gx) + u16vec4(0,1,2,3);
+    bf16vec4 b = uintBitsToBFloat16EXT(uint16_t(lx) + u16vec4(2,3,5,7));
 
     for (int i = 0; i < loop; i++)
     {
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
-        c = float(dot(a, b)) + c;
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.x = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.y = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.z = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.w = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.x = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.y = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.z = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.w = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.x = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.y = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.z = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.w = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.x = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.y = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.z = bfloat16BitsToUintEXT(c);
+        c = dot(uintBitsToBFloat16EXT(a), b);
+        a.w = bfloat16BitsToUintEXT(c);
     }
 
-    c_blob_data[gx] = c;
+    c_blob_data[gx] = float(c);
 }
 )";
 
@@ -834,34 +850,50 @@ void main()
     const uint gx = gl_GlobalInvocationID.x;
     const uint lx = gl_LocalInvocationID.x;
 
-    float c0 = float(gx);
-    float c1 = float(lx);
+    bfloat16_t c0 = bfloat16_t(gx);
+    bfloat16_t c1 = bfloat16_t(lx);
 
-    bf16vec4 a = bf16vec4(bfloat16_t(gx + vec4(0,1,2,-3)));
-    bf16vec4 b = bf16vec4(bfloat16_t(lx + vec4(2,3,5,-7)));
+    u16vec4 a0 = uint16_t(gx) + u16vec4(0,1,2,3);
+    u16vec4 a1 = uint16_t(gx) + u16vec4(10,21,32,43);
+    bf16vec4 b = uintBitsToBFloat16EXT(uint16_t(lx) + u16vec4(2,3,5,7));
 
     for (int i = 0; i < loop; i++)
     {
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
-        c0 = float(dot(a, b)) + c0;
-        c1 = float(dot(a, b)) + c1;
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.x = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.y = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.z = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.w = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.x = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.y = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.z = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.w = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.x = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.y = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.z = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.w = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.x = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.y = bfloat16BitsToUintEXT(c1);
+        c0 = dot(uintBitsToBFloat16EXT(a0), b);
+        a0.z = bfloat16BitsToUintEXT(c0);
+        c1 = dot(uintBitsToBFloat16EXT(a1), b);
+        a1.w = bfloat16BitsToUintEXT(c1);
     }
 
-    c0 = c0 + c1;
-    c_blob_data[gx] = c0;
+    c_blob_data[gx] = float(c0) + float(c1);
 }
 )";
 


### PR DESCRIPTION
- [x] update ncnn
- [x] dual issue mla
- [x] even less data load
- [x] fp16 arithmetic without storage
- [x] flexible matrix m-n-k
- [x] more matrix m-n-k types
- [x] int8 dotprod
- [x] int8 matrix (depend on ncnn expose more matrix properties)
- [x] bfloat16 dotprod (depend on ncnn update glslang)
- [x] bfloat16 matrix (depend on ncnn update glslang and expose more matrix properties)
- [ ] enable matrix on mesa radv and anv (depend on ncnn fix)

```
device       = NVIDIA GeForce RTX 3060

fp32-scalar  = 9383.37 GFLOPS
fp32-vec4    = 11015.56 GFLOPS

fp16-scalar  = 13885.98 GFLOPS
fp16-vec4    = 10322.27 GFLOPS
fp16-matrix  = 55821.03 GFLOPS

fp64-scalar  = 218.60 GFLOPS
fp64-vec4    = 218.63 GFLOPS

int32-scalar = 7038.46 GIOPS
int32-vec4   = 6993.63 GIOPS

int16-scalar = 5494.88 GIOPS
int16-vec4   = 5816.82 GIOPS

int8-dotprod = 6700.98 GIOPS
int8-matrix  = 110729.41 GIOPS
```



|asahilinux|m1|m2|
|---|---|---|
| fp32-scalar  | 869.14  | 952.87  |
| fp32-vec4    | 919.98  | 1018.72 |
| fp16-scalar  | 1245.98 | 1362.06 |
| fp16-vec4    | 2100.52 | 2306.50 |
| int32-scalar | 628.29  | 687.04  |
| int32-vec4   | 646.12  | 707.44  |
| int16-scalar | 647.05  | 707.58  |
| int16-vec4   | 651.72  | 713.51  |
| int8-dotprod | 2151.60 | 2376.69 |



|macos|m1|m2|m3|m4|
|---|---|---|---|---|
| fp32-scalar  | 2092.68 | 2297.63 | 3344.90  | 3841.09  |
| fp32-vec4    | 2381.70 | 2603.13 | 3230.04  | 3700.21  |
| fp16-scalar  | 2198.92 | 2427.09 | 3322.85  | 3840.79  |
| fp16-vec4    | 2495.72 | 2730.82 | 3398.41  | 3899.43  |
| int32-scalar | 651.10  | 712.79  | 855.82   | 981.37   |
| int32-vec4   | 651.95  | 713.61  | 855.87   | 980.31   |
| int16-scalar | 647.64  | 708.52  | 855.62   | 981.79   |
| int16-vec4   | 653.83  | 715.01  | 855.92   | 980.67   |
| int8-dotprod | 8821.90 | 9664.55 | 12145.30 | 13941.50 |
